### PR TITLE
Fix Elixir 1.4 warnings

### DIFF
--- a/lib/mix/tasks/install.ex
+++ b/lib/mix/tasks/install.ex
@@ -24,9 +24,9 @@ defmodule Mix.Tasks.PhoenixReactor.Install do
   """
 
   def run(opts) do
-    init_npm
-    install_react
-    unless Enum.member?(opts, "--no-webpack"), do: install_webpack
+    init_npm()
+    install_react()
+    unless Enum.member?(opts, "--no-webpack"), do: install_webpack()
   end
 
   @priv_source_dir "./_build/dev/lib/phoenix_reactor/priv"

--- a/mix.exs
+++ b/mix.exs
@@ -7,9 +7,9 @@ defmodule PhoenixReactor.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
-     package: package,
-     description: description]
+     deps: deps(),
+     package: package(),
+     description: description()]
   end
 
   # Type "mix help compile.app" for more information

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
-%{"earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.5"},
-  "phoenix_html": {:hex, :phoenix_html, "2.5.1"},
-  "plug": {:hex, :plug, "1.1.4"},
-  "poison": {:hex, :poison, "1.5.2"}}
+%{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "phoenix_html": {:hex, :phoenix_html, "2.5.1", "631053f9e345fecb5c87d9e0ccd807f7266d27e2ee4269817067af425fd81ba8", [:mix], [{:plug, "~> 0.13 or ~> 1.0", [hex: :plug, optional: false]}]},
+  "plug": {:hex, :plug, "1.1.4", "2eee0e85ad420db96e075b3191d3764d6fff61422b101dc5b02e9cce99cacfc7", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
+  "poison": {:hex, :poison, "1.5.2", "560bdfb7449e3ddd23a096929fb9fc2122f709bcc758b2d5d5a5c7d0ea848910", [:mix], []}}


### PR DESCRIPTION
Functions without parameters should be called with parenthesis.